### PR TITLE
Create InternalPosts Object

### DIFF
--- a/fuzzly/__init__.py
+++ b/fuzzly/__init__.py
@@ -1,7 +1,7 @@
 """A python client library for fuzz.ly"""  # this comment should match the package slogan under the logo in the readme
 
 
-__version__: str = '0.0.2'
+__version__: str = '0.0.3'
 
 
 from typing import List

--- a/fuzzly/models/_database.py
+++ b/fuzzly/models/_database.py
@@ -1,15 +1,15 @@
 from asyncio import Task, ensure_future
 from datetime import datetime
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Coroutine, Any
+from typing import Any, Callable, Coroutine, Dict, Iterable, List, Optional, Tuple
 
 from kh_common.auth import KhUser
 from kh_common.caching import AerospikeCache, SimpleCache
 from kh_common.caching.key_value_store import KeyValueStore
 from kh_common.exceptions.http_error import NotFound
 from kh_common.sql import SqlInterface
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, Field, validator
 
-from ._shared import Badge, PostId, User, UserPortable, UserPrivacy, Verified, _post_id_converter, UserPrivacy
+from ._shared import Badge, PostId, User, UserPortable, UserPrivacy, Verified, _post_id_converter
 from .post import PostId, Score
 
 
@@ -34,9 +34,9 @@ class InternalUser(BaseModel) :
 	verified: Optional[Verified]
 	badges: List[Badge]
 
-	_following: Callable[['InternalUser', KhUser], Coroutine[Any, Any, bool]]
-	user: Callable[['InternalUser', Optional[KhUser]], Coroutine[Any, Any, User]]
-	portable: Callable[['InternalUser', Optional[KhUser]], Coroutine[Any, Any, UserPortable]]
+	_following: Callable[['InternalUser', KhUser], Coroutine[Any, Any, bool]] = Field(exclude=True)
+	user: Callable[['InternalUser', Optional[KhUser]], Coroutine[Any, Any, User]] = Field(exclude=True)
+	portable: Callable[['InternalUser', Optional[KhUser]], Coroutine[Any, Any, UserPortable]] = Field(exclude=True)
 
 
 class InternalScore(BaseModel) :

--- a/fuzzly/models/_database.py
+++ b/fuzzly/models/_database.py
@@ -1,9 +1,9 @@
 from asyncio import Task, ensure_future
 from datetime import datetime
-from typing import Any, Callable, Coroutine, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple
 
 from kh_common.auth import KhUser
-from kh_common.caching import AerospikeCache, SimpleCache
+from kh_common.caching import AerospikeCache
 from kh_common.caching.key_value_store import KeyValueStore
 from kh_common.exceptions.http_error import NotFound
 from kh_common.sql import SqlInterface

--- a/fuzzly/models/_database.py
+++ b/fuzzly/models/_database.py
@@ -289,7 +289,7 @@ class DBI(SqlInterface) :
 				INNER JOIN kheina.public.tags
 					ON tags.tag_id = tag_post.tag_id
 						AND tags.deprecated = false
-			WHERE tag_post.post_id = %s
+			WHERE tag_post.post_id = any(%s)
 			GROUP BY tag_post.post_id;
 			""",
 			(list(map(int, post_ids)),),

--- a/fuzzly/models/_database.py
+++ b/fuzzly/models/_database.py
@@ -17,6 +17,7 @@ FollowKVS: KeyValueStore = KeyValueStore('kheina', 'following')
 ScoreCache: KeyValueStore = KeyValueStore('kheina', 'score')
 VoteCache: KeyValueStore = KeyValueStore('kheina', 'votes')
 CountKVS: KeyValueStore = KeyValueStore('kheina', 'tag_count',  local_TTL=60)
+UserKVS: KeyValueStore = KeyValueStore('kheina', 'users', local_TTL=60)
 
 
 class InternalUser(BaseModel) :
@@ -270,7 +271,7 @@ class DBI(SqlInterface) :
 			post_id: PostId = PostId(post_id)
 			vote: int = 1 if upvote else -1
 			votes[post_id] = vote
-			ensure_future(VoteCache.put_async(post_id, vote))
+			ensure_future(VoteCache.put_async(f'{user_id}|{post_id}', vote))
 
 		return votes
 
@@ -415,6 +416,6 @@ class DBI(SqlInterface) :
 				badges = list(map(badge_map.__getitem__, datum[12])),
 			)
 			users[datum[0]] = user
-			ensure_future(VoteCache.put_async(str(datum[0]), user))
+			ensure_future(UserKVS.put_async(str(datum[0]), user))
 
 		return users

--- a/fuzzly/models/_database.py
+++ b/fuzzly/models/_database.py
@@ -335,8 +335,8 @@ class DBI(SqlInterface) :
 			fetch_all=True,
 		)
 
-		for datum in data :
-			tags[PostId(datum[0])] = datum[1]
+		for post_id, tag_list in data :
+			tags[PostId(post_id)] = list(filter(None, tag_list))
 
 		return tags
 
@@ -413,7 +413,7 @@ class DBI(SqlInterface) :
 				description = datum[7],
 				banner = datum[8],
 				verified = verified,
-				badges = list(map(badge_map.__getitem__, datum[12])),
+				badges = list(map(badge_map.__getitem__, filter(None, datum[12]))),
 			)
 			users[datum[0]] = user
 			ensure_future(UserKVS.put_async(str(datum[0]), user))

--- a/fuzzly/models/_database.py
+++ b/fuzzly/models/_database.py
@@ -104,7 +104,7 @@ class PrivacyMap(SqlInterface, dict) :
 	def __missing__(self, key: int) -> UserPrivacy :
 		data: Tuple[str] = self.query(f"""
 			SELECT type
-			FROM kheina.public.privacy;
+			FROM kheina.public.privacy
 			WHERE privacy_id = %s
 			LIMIT 1;
 			""",

--- a/fuzzly/models/_database.py
+++ b/fuzzly/models/_database.py
@@ -1,13 +1,15 @@
 from asyncio import Task, ensure_future
-from typing import Dict, List, Optional
+from datetime import datetime
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Coroutine, Any
 
 from kh_common.auth import KhUser
-from kh_common.caching import AerospikeCache
+from kh_common.caching import AerospikeCache, SimpleCache
 from kh_common.caching.key_value_store import KeyValueStore
 from kh_common.exceptions.http_error import NotFound
 from kh_common.sql import SqlInterface
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
+from ._shared import Badge, PostId, User, UserPortable, UserPrivacy, Verified, _post_id_converter, UserPrivacy
 from .post import PostId, Score
 
 
@@ -17,10 +19,68 @@ VoteCache: KeyValueStore = KeyValueStore('kheina', 'votes')
 CountKVS: KeyValueStore = KeyValueStore('kheina', 'tag_count',  local_TTL=60)
 
 
+class InternalUser(BaseModel) :
+	_post_id_converter = validator('icon', 'banner', pre=True, always=True, allow_reuse=True)(_post_id_converter)
+
+	user_id: int
+	name: str
+	handle: str
+	privacy: UserPrivacy
+	icon: Optional[PostId]
+	banner: Optional[PostId]
+	website: Optional[str]
+	created: datetime
+	description: Optional[str]
+	verified: Optional[Verified]
+	badges: List[Badge]
+
+	_following: Callable[['InternalUser', KhUser], Coroutine[Any, Any, bool]]
+	user: Callable[['InternalUser', Optional[KhUser]], Coroutine[Any, Any, User]]
+	portable: Callable[['InternalUser', Optional[KhUser]], Coroutine[Any, Any, UserPortable]]
+
+
 class InternalScore(BaseModel) :
 	up: int
 	down: int
 	total: int
+
+
+# this steals the idea of a map from kh_common.map.Map, probably use that when types are figured out in a generic way
+class BadgeMap(SqlInterface, dict) :
+
+	def __missing__(self, key: int) -> Badge :
+		data: Tuple[str, str] = self.query(f"""
+			SELECT emoji, label
+			FROM kheina.public.badges
+			WHERE badge_id = %s
+			LIMIT 1;
+			""",
+			(key,),
+			fetch_one=True,
+		)
+		self[key] = Badge(emoji=data[0], label=data[1])
+		return self[key]
+
+badge_map: BadgeMap = BadgeMap()
+
+
+# this steals the idea of a map from kh_common.map.Map, probably use that when types are figured out in a generic way
+class PrivacyMap(SqlInterface, dict) :
+
+	def __missing__(self, key: int) -> UserPrivacy :
+		data: Tuple[str] = self.query(f"""
+			SELECT type
+			FROM kheina.public.privacy;
+			WHERE privacy_id = %s
+			LIMIT 1;
+			""",
+			(key,),
+			fetch_one=True,
+		)
+		self[key] = UserPrivacy(value=data[0])
+		return self[key]
+
+privacy_map: PrivacyMap = PrivacyMap()
 
 
 class DBI(SqlInterface) :
@@ -47,6 +107,39 @@ class DBI(SqlInterface) :
 		return bool(data[0])
 
 
+	async def following_many(self, user_id: int, targets: Iterable[int]) -> Dict[int, bool] :
+		"""
+		returns a map of target user id -> following bool
+		"""
+
+		targets: List[int] = list(targets)
+
+		data: List[Tuple[int, int]] = await self.query_async("""
+			SELECT following.follows, count(1)
+			FROM kheina.public.following
+			WHERE following.user_id = %s
+				AND following.follows = any(%s)
+			GROUP BY following.follows;
+			""",
+			(user_id, targets),
+			fetch_all=True,
+		)
+
+		return_value: Dict[int, bool] = {
+			target: False
+			for target in targets
+		}
+		return_value.update({
+			k: bool(v)
+			for k, v in data
+		})
+
+		for target, following in return_value.items() :
+			ensure_future(FollowKVS.put_async(f'{user_id}|{target}', following))
+
+		return return_value
+
+
 	@AerospikeCache('kheina', 'score', '{post_id}', _kvs=ScoreCache)
 	async def _get_score(self, post_id: PostId) -> Optional[InternalScore] :
 		data: List[int] = await self.query_async("""
@@ -54,7 +147,7 @@ class DBI(SqlInterface) :
 				post_scores.upvotes,
 				post_scores.downvotes
 			FROM kheina.public.post_scores
-			WHERE post_scores.post_id = %s
+			WHERE post_scores.post_id = %s;
 			""",
 			(post_id.int(),),
 			fetch_one=True,
@@ -70,7 +163,38 @@ class DBI(SqlInterface) :
 		)
 
 
-	@AerospikeCache('kheina', 'votes', '{user}.{post_id}', _kvs=VoteCache)
+	async def scores_many(self, post_ids: List[PostId]) -> Dict[PostId, Optional[InternalScore]] :
+		scores: Dict[PostId, Optional[InternalScore]] = {
+			post_id: None
+			for post_id in post_ids
+		}
+
+		data: List[Tuple(int, int, int)] = await self.query_async("""
+			SELECT
+				post_scores.post_id,
+				post_scores.upvotes,
+				post_scores.downvotes
+			FROM kheina.public.post_scores
+			WHERE post_scores.post_id = any(%s);
+			""",
+			(list(map(int, post_ids)),),
+			fetch_all=True,
+		)
+
+		if not data :
+			return scores
+
+		for datum in data :
+			scores[PostId(datum[0])] = InternalScore(
+				up=datum[1],
+				down=datum[2],
+				total=datum[1] + datum[2],
+			)
+
+		return scores
+
+
+	@AerospikeCache('kheina', 'votes', '{user_id}|{post_id}', _kvs=VoteCache)
 	async def _get_vote(self, user_id: int, post_id: PostId) -> int :
 		data: List[int] = await self.query_async("""
 			SELECT
@@ -87,6 +211,32 @@ class DBI(SqlInterface) :
 			return 0
 
 		return 1 if data[0] else -1
+
+
+	async def votes_many(self, user_id: int, post_ids: List[PostId]) -> Dict[PostId, int] :
+		votes: Dict[PostId, int] = {
+			post_id: 0
+			for post_id in post_ids
+		}
+		data: List[int] = await self.query_async("""
+			SELECT
+				post_votes.post_id,
+				post_votes.upvote
+			FROM kheina.public.post_votes
+			WHERE post_votes.user_id = %s
+				AND post_votes.post_id = any(%s);
+			""",
+			(user_id, list(map(int, post_ids))),
+			fetch_all=True,
+		)
+
+		if not data :
+			return votes
+
+		for datum in data :
+			votes[PostId(datum[0])] = 1 if datum[0] else -1
+
+		return votes
 
 
 	async def getScore(self, user: KhUser, post_id: PostId) -> Optional[Score] :
@@ -106,7 +256,7 @@ class DBI(SqlInterface) :
 		)
 
 
-	@AerospikeCache('kheina', 'votes', '{tag}', _kvs=CountKVS)
+	@AerospikeCache('kheina', 'tag_count', '{tag}', _kvs=CountKVS)
 	async def tagCount(self, tag: str) -> int :
 		data = await self.query_async("""
 			SELECT COUNT(1)
@@ -128,6 +278,30 @@ class DBI(SqlInterface) :
 		return data[0]
 
 
+	async def tags_many(self, post_ids: List[PostId]) -> Dict[PostId, List[str]] :
+		tags: Dict[PostId, List[str]] = {
+			post_ids: []
+			for post_id in post_ids
+		}
+		data: List[Tuple[int, List[str]]] = await self.query_async("""
+			SELECT tag_post.post_id, array_agg(tags.tag)
+			FROM kheina.public.tag_post
+				INNER JOIN kheina.public.tags
+					ON tags.tag_id = tag_post.tag_id
+						AND tags.deprecated = false
+			WHERE tag_post.post_id = %s
+			GROUP BY tag_post.post_id;
+			""",
+			(list(map(int, post_ids)),),
+			fetch_all=True,
+		)
+
+		for datum in data :
+			tags[PostId(datum[0])] = datum[1]
+
+		return tags
+
+
 	async def _handle_to_user_id(self, handle: str) -> int :
 		data = await self.query_async("""
 			SELECT
@@ -143,3 +317,65 @@ class DBI(SqlInterface) :
 			raise NotFound('no data was found for the provided user.')
 
 		return data[0]
+
+
+	async def users_many(self, user_ids: Iterable[int]) -> Dict[int, InternalUser] :
+		user_ids: List[int] = list(user_ids)
+
+		data: List[tuple] = await self.query_async("""
+			SELECT
+				users.user_id,
+				users.display_name,
+				users.handle,
+				users.privacy_id,
+				users.icon,
+				users.website,
+				users.created_on,
+				users.description,
+				users.banner,
+				users.admin,
+				users.mod,
+				users.verified,
+				array_agg(user_badge.badge_id)
+			FROM kheina.public.users
+				LEFT JOIN kheina.public.user_badge
+					ON user_badge.user_id = users.user_id
+			WHERE users.user_id = any(%s)
+			GROUP BY
+				users.user_id;
+			""",
+			(user_ids,),
+			fetch_all=True,
+		)
+
+		if not data :
+			return { }
+
+		users: Dict[int, InternalUser] = { }
+		for datum in data :
+			verified: Optional[Verified] = None
+
+			if datum[9] :
+				verified = Verified.admin
+
+			elif datum[10] :
+				verified = Verified.mod
+
+			elif datum[11] :
+				verified = Verified.artist
+
+			users[datum[0]] = InternalUser(
+				user_id = datum[0],
+				name = datum[1],
+				handle = datum[2],
+				privacy = privacy_map[datum[3]],
+				icon = datum[4],
+				website = datum[5],
+				created = datum[6],
+				description = datum[7],
+				banner = datum[8],
+				verified = verified,
+				badges = list(map(badge_map.__getitem__, datum[12])),
+			)
+
+		return users

--- a/fuzzly/models/_database.py
+++ b/fuzzly/models/_database.py
@@ -280,7 +280,7 @@ class DBI(SqlInterface) :
 
 	async def tags_many(self, post_ids: List[PostId]) -> Dict[PostId, List[str]] :
 		tags: Dict[PostId, List[str]] = {
-			post_ids: []
+			post_id: []
 			for post_id in post_ids
 		}
 		data: List[Tuple[int, List[str]]] = await self.query_async("""

--- a/fuzzly/models/_shared.py
+++ b/fuzzly/models/_shared.py
@@ -67,8 +67,14 @@ class PostId(str) :
 
 			return super(PostId, cls).__new__(cls, PostId._str_from_bytes(value))
 
-		else :
-			raise NotImplementedError('value must be of type str, bytes, or int.')
+		# just in case there's some weirdness happening with types, but it's still a string
+		if isinstance(value, str) :
+			if not PostId.__str_format__.match(value) :
+				raise ValueError('str values must be in the format of /^[a-zA-Z0-9_-]{8}$/')
+
+			return super(PostId, cls).__new__(cls, value)
+
+		raise NotImplementedError('value must be of type str, bytes, or int.')
 
 
 	@lru_cache(maxsize=128)

--- a/fuzzly/models/_shared.py
+++ b/fuzzly/models/_shared.py
@@ -29,6 +29,17 @@ class PostId(str) :
 
 	__str_format__: Pattern = re_compile(r'^[a-zA-Z0-9_-]{8}$')
 
+
+	@lru_cache(maxsize=128)
+	def _str_from_int(value: int) -> str :
+		return b64encode(int.to_bytes(value, 6, 'big')).decode()
+
+
+	@lru_cache(maxsize=128)
+	def _str_from_bytes(value: bytes) -> str :
+		return b64encode(value).decode()
+
+
 	def __new__(cls, value: Union[str, bytes, int]) :
 		# technically, the only thing needed to be done here to utilize the full 64 bit range is update the 6 bytes encoding to 8 and the allowed range in the int subtype
 
@@ -48,13 +59,13 @@ class PostId(str) :
 			if not 0 <= value <= 281474976710655 :
 				raise ValueError('int values must be between 0 and 281474976710655.')
 
-			return super(PostId, cls).__new__(cls, b64encode(int.to_bytes(value, 6, 'big')).decode())
+			return super(PostId, cls).__new__(cls, PostId._str_from_int(value))
 
 		elif value_type == bytes :
 			if len(value) != 6 :
 				raise ValueError('bytes values must be exactly 6 bytes.')
 
-			return super(PostId, cls).__new__(cls, b64encode(value).decode())
+			return super(PostId, cls).__new__(cls, PostId._str_from_bytes(value))
 
 		else :
 			raise NotImplementedError('value must be of type str, bytes, or int.')

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -370,10 +370,10 @@ _InternalClient.tags_many = tags_many
 
 
 class InternalPosts(BaseModel) :
-	_posts: List[InternalPost] = []
+	post_list: List[InternalPost] = []
 
 	def append(self: 'InternalPosts', post: InternalPost) :
-		return self._posts.append(post)
+		return self.post_list.append(post)
 
 
 	async def uploaders(self: 'InternalPosts', client: _InternalClient, user: KhUser) -> Dict[int, User] :
@@ -382,7 +382,7 @@ class InternalPosts(BaseModel) :
 
 		:return: dict in the form user id -> populated User object
 		"""
-		uploader_ids: List[int] = list(set(map(lambda x : x.user_id, self._posts)))
+		uploader_ids: List[int] = list(set(map(lambda x : x.user_id, self.post_list)))
 		users_task: Task[Dict[int, InternalUser]] = ensure_future(client.users_many(uploader_ids))
 		following: Dict[int, Optional[bool]]
 
@@ -421,7 +421,7 @@ class InternalPosts(BaseModel) :
 		scores: Dict[PostId, Optional[Score]] = { }
 		post_ids: List[PostId] = []
 
-		for post in self._posts :
+		for post in self.post_list :
 			post_id: PostId = PostId(post.post_id)
 
 			# only grab posts that can actually have scores
@@ -463,12 +463,12 @@ class InternalPosts(BaseModel) :
 		uploaders_task: Task[Dict[int, User]] = ensure_future(self.uploaders(client, user))
 		scores_task: Task[Dict[PostId, Optional[Score]]] = ensure_future(self.scores(client, user))
 
-		tags: Dict[PostId, List[str]] = await client.tags_many(list(map(lambda x : PostId(x.post_id), self._posts)))
+		tags: Dict[PostId, List[str]] = await client.tags_many(list(map(lambda x : PostId(x.post_id), self.post_list)))
 		uploaders: Dict[int, User] = await uploaders_task
 		scores: Dict[PostId, Optional[Score]] = await scores_task
 
 		posts: List[Post] = []
-		for post in self._posts :
+		for post in self.post_list :
 			post_id: PostId = PostId(post.post_id)
 			posts.append(Post(
 				post_id=post_id,

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -360,7 +360,7 @@ async def users_many(self: _InternalClient, user_ids: List[int]) -> Dict[int, In
 	}
 
 	# remember we need to convert the dict key from the string needed for aerospike back to an int
-	sql_user_ids: List[int] = [user_id for user_id, user in users if user is None]
+	sql_user_ids: List[int] = [user_id for user_id, user in users.items() if user is None]
 	users.update(await DB.users_many(sql_user_ids))
 
 	return users
@@ -475,7 +475,7 @@ class InternalPosts(BaseModel) :
 		iscores_task: Task[Dict[PostId, Optional[InternalScore]]] = ensure_future(client.scores_many(post_ids))
 		user_votes: Dict[PostId, int]
 
-		if user.authenticated(False) :
+		if await user.authenticated(False) :
 			user_votes = await client.votes_many(post_ids)
 
 		else :

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from ..client import Client
 from ..constants import ConfigHost, PostHost, TagHost, UserHost
-from ._database import DBI, FollowKVS, InternalScore, InternalUser, ScoreCache, VoteCache
+from ._database import DBI, FollowKVS, InternalScore, InternalUser, ScoreCache, UserKVS, VoteCache
 from ._shared import Badge, PostId, PostSize, User, UserPortable, UserPrivacy, Verified, _post_id_converter
 from .config import UserConfig
 from .post import MediaType, Post, PostId, PostSize, PostSort, Privacy, Rating, Score
@@ -23,7 +23,6 @@ from .user import UserPortable
 # each internal endpoint will have it's own exported kvs so that they can be overwritten or imported by users
 UserConfigKVS: KeyValueStore = KeyValueStore('kheina', 'configs')
 TagKVS: KeyValueStore = KeyValueStore('kheina', 'tags')
-UserKVS: KeyValueStore = KeyValueStore('kheina', 'users', local_TTL=60)
 PostKVS: KeyValueStore = KeyValueStore('kheina', 'posts')
 
 # internal functions sometimes need to interact with the db, this is done through this interface

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -8,7 +8,7 @@ from kh_common.caching import AerospikeCache, ArgsCache
 from kh_common.caching.key_value_store import KeyValueStore
 from kh_common.gateway import Gateway
 from kh_common.utilities import flatten
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from ..client import Client
 from ..constants import ConfigHost, PostHost, TagHost, UserHost
@@ -43,13 +43,13 @@ class _InternalClient(Client) :
 	_user: Gateway  # this will be assigned later
 	_tag: Gateway  # this will be assigned later
 
-	following_many: Callable[[KhUser, List[int]], Coroutine[Any, Any, Dict[int, bool]]] = Field(exclude=True)
-	users_many: Callable[[List[int]], Coroutine[Any, Any, Dict[int, InternalUser]]] = Field(exclude=True)
+	following_many: Callable[[KhUser, List[int]], Coroutine[Any, Any, Dict[int, bool]]]
+	users_many: Callable[[List[int]], Coroutine[Any, Any, Dict[int, InternalUser]]]
 
-	votes_many: Callable[[KhUser, List[PostId]], Coroutine[Any, Any, Dict[PostId, int]]] = Field(exclude=True)
-	scores_many: Callable[[List[PostId]], Coroutine[Any, Any, Dict[PostId, Optional[InternalScore]]]] = Field(exclude=True)
+	votes_many: Callable[[KhUser, List[PostId]], Coroutine[Any, Any, Dict[PostId, int]]]
+	scores_many: Callable[[List[PostId]], Coroutine[Any, Any, Dict[PostId, Optional[InternalScore]]]]
 
-	tags_many: Callable[[List[PostId]], Coroutine[Any, Any, Dict[PostId, List[str]]]] = Field(exclude=True)
+	tags_many: Callable[[List[PostId]], Coroutine[Any, Any, Dict[PostId, List[str]]]]
 
 
 	def __hash__(self: '_InternalClient') -> int :
@@ -181,47 +181,6 @@ async def _following(self: 'InternalUser', user: KhUser) -> bool :
 	return await follow_task
 
 InternalUser._following = _following
-
-
-async def user(self: 'InternalUser', user: Optional[KhUser] = None) -> User :
-	following: Optional[bool] = None
-
-	if user :
-		following = await self._following(user)
-
-	return User(
-		name = self.name,
-		handle = self.handle,
-		privacy = self.privacy,
-		icon = self.icon,
-		banner = self.banner,
-		website = self.website,
-		created = self.created,
-		description = self.description,
-		verified = self.verified,
-		following = following,
-		badges = self.badges,
-	)
-
-InternalUser.user = user
-
-
-async def portable(self: 'InternalUser', user: Optional[KhUser] = None) -> UserPortable :
-	following: Optional[bool] = None
-
-	if user :
-		following = await self._following(user)
-
-	return UserPortable(
-		name = self.name,
-		handle = self.handle,
-		privacy = self.privacy,
-		icon = self.icon,
-		verified = self.verified,
-		following = following,
-	)
-
-InternalUser.portable = portable
 
 
 # this has to be defined here because of the response model

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -376,7 +376,7 @@ async def votes_many(self: _InternalClient, user: KhUser, post_ids: List[PostId]
 		(await VoteCache.get_many_async(votes_map.keys())).items()
 	}
 
-	sql_post_ids: List[PostId] = [post_id for post_id, vote in votes.items() if vote is None]
+	sql_post_ids: List[PostId] = [PostId(post_id) for post_id, vote in votes.items() if vote is None]
 	votes.update(await DB.votes_many(user.user_id, sql_post_ids))
 
 	return votes
@@ -387,7 +387,7 @@ _InternalClient.votes_many = votes_many
 async def scores_many(self: _InternalClient, post_ids: List[PostId]) -> Dict[PostId, Optional[InternalScore]] :
 	scores: Dict[PostId, Optional[InternalScore]] = await ScoreCache.get_many_async(post_ids)
 
-	sql_post_ids: List[PostId] = [post_id for post_id, score in scores.items() if score is None]
+	sql_post_ids: List[PostId] = [PostId(post_id) for post_id, score in scores.items() if score is None]
 	scores.update(await DB.scores_many(sql_post_ids))
 
 	return scores
@@ -402,7 +402,7 @@ async def tags_many(self: _InternalClient, post_ids: List[PostId]) -> Dict[PostI
 		(await TagKVS.get_many_async(post_ids)).items()
 	}
 
-	sql_post_ids: List[PostId] = [post_id for post_id, tag_list in tags.items() if tag_list is None]
+	sql_post_ids: List[PostId] = [PostId(post_id) for post_id, tag_list in tags.items() if tag_list is None]
 	tags.update(await DB.tags_many(sql_post_ids))
 
 	return tags

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -332,7 +332,7 @@ _InternalClient.users_many = users_many
 
 
 async def votes_many(self: _InternalClient, user: KhUser, post_ids: List[PostId]) -> Dict[PostId, int] :
-	votes_map: Dict[str, PostId] = dict(map(map(lambda x : (f'{user.user_id}|{x}', x), post_ids)))
+	votes_map: Dict[str, PostId] = dict(map(lambda x : (f'{user.user_id}|{x}', x), post_ids))
 	votes: Dict[PostId, Optional[int]] = {
 		votes_map[key]: vote
 		for key, vote in

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -301,8 +301,10 @@ async def following_many(self: _InternalClient, user: KhUser, targets: List[int]
 		(await FollowKVS.get_many_async(following_map.keys())).items()
 	}
 
-	sql_following_uploader_ids: List[int] = [target for target, f in following.items() if f is None]
-	following.update(await DB.following_many(user.user_id, sql_following_uploader_ids))
+	sql_user_ids: List[int] = [target for target, f in following.items() if f is None]
+
+	if sql_user_ids :
+		following.update(await DB.following_many(user.user_id, sql_user_ids))
 
 	return following
 
@@ -320,7 +322,9 @@ async def users_many(self: _InternalClient, user_ids: List[int]) -> Dict[int, In
 	}
 
 	sql_user_ids: List[int] = [user_id for user_id, user in users.items() if user is None or type(user) == bytearray]
-	users.update(await DB.users_many(sql_user_ids))
+
+	if sql_user_ids :
+		users.update(await DB.users_many(sql_user_ids))
 
 	return users
 
@@ -336,7 +340,9 @@ async def votes_many(self: _InternalClient, user: KhUser, post_ids: List[PostId]
 	}
 
 	sql_post_ids: List[PostId] = [PostId(post_id) for post_id, vote in votes.items() if vote is None]
-	votes.update(await DB.votes_many(user.user_id, sql_post_ids))
+
+	if sql_post_ids :
+		votes.update(await DB.votes_many(user.user_id, sql_post_ids))
 
 	return votes
 
@@ -347,7 +353,9 @@ async def scores_many(self: _InternalClient, post_ids: List[PostId]) -> Dict[Pos
 	scores: Dict[PostId, Optional[InternalScore]] = await ScoreCache.get_many_async(post_ids)
 
 	sql_post_ids: List[PostId] = [PostId(post_id) for post_id, score in scores.items() if score is None or type(score) == bytearray]
-	scores.update(await DB.scores_many(sql_post_ids))
+
+	if sql_post_ids :
+		scores.update(await DB.scores_many(sql_post_ids))
 
 	return scores
 
@@ -362,7 +370,9 @@ async def tags_many(self: _InternalClient, post_ids: List[PostId]) -> Dict[PostI
 	}
 
 	sql_post_ids: List[PostId] = [PostId(post_id) for post_id, tag_list in tags.items() if tag_list is None]
-	tags.update(await DB.tags_many(sql_post_ids))
+
+	if sql_post_ids :
+		tags.update(await DB.tags_many(sql_post_ids))
 
 	return tags
 
@@ -435,7 +445,7 @@ class InternalPosts(BaseModel) :
 		user_votes: Dict[PostId, int]
 
 		if await user.authenticated(False) :
-			user_votes = await client.votes_many(post_ids)
+			user_votes = await client.votes_many(user, post_ids)
 
 		else :
 			user_votes = defaultdict(lambda : 0)

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -1,18 +1,18 @@
 from asyncio import Task, ensure_future
-from datetime import datetime
-from typing import Dict, Iterable, List, Optional, Set, Tuple, Callable, Coroutine, Any
 from collections import defaultdict
+from datetime import datetime
+from typing import Any, Callable, Coroutine, Dict, Iterable, List, Optional, Set, Tuple
 
 from kh_common.auth import KhUser
 from kh_common.caching import AerospikeCache, ArgsCache
 from kh_common.caching.key_value_store import KeyValueStore
 from kh_common.gateway import Gateway
-from pydantic import BaseModel
 from kh_common.utilities import flatten
+from pydantic import BaseModel, Field
 
 from ..client import Client
 from ..constants import ConfigHost, PostHost, TagHost, UserHost
-from ._database import DBI, FollowKVS, VoteCache, ScoreCache, InternalScore, InternalUser
+from ._database import DBI, FollowKVS, InternalScore, InternalUser, ScoreCache, VoteCache
 from ._shared import Badge, PostId, PostSize, User, UserPortable, UserPrivacy, Verified, _post_id_converter
 from .config import UserConfig
 from .post import MediaType, Post, PostId, PostSize, PostSort, Privacy, Rating, Score
@@ -43,13 +43,13 @@ class _InternalClient(Client) :
 	_user: Gateway  # this will be assigned later
 	_tag: Gateway  # this will be assigned later
 
-	following_many: Callable[[KhUser, List[int]], Coroutine[Any, Any, Dict[int, bool]]]
-	users_many: Callable[[List[int]], Coroutine[Any, Any, Dict[int, InternalUser]]]
+	following_many: Callable[[KhUser, List[int]], Coroutine[Any, Any, Dict[int, bool]]] = Field(exclude=True)
+	users_many: Callable[[List[int]], Coroutine[Any, Any, Dict[int, InternalUser]]] = Field(exclude=True)
 
-	votes_many: Callable[[KhUser, List[PostId]], Coroutine[Any, Any, Dict[PostId, int]]]
-	scores_many: Callable[[List[PostId]], Coroutine[Any, Any, Dict[PostId, Optional[InternalScore]]]]
+	votes_many: Callable[[KhUser, List[PostId]], Coroutine[Any, Any, Dict[PostId, int]]] = Field(exclude=True)
+	scores_many: Callable[[List[PostId]], Coroutine[Any, Any, Dict[PostId, Optional[InternalScore]]]] = Field(exclude=True)
 
-	tags_many: Callable[[List[PostId]], Coroutine[Any, Any, Dict[PostId, List[str]]]]
+	tags_many: Callable[[List[PostId]], Coroutine[Any, Any, Dict[PostId, List[str]]]] = Field(exclude=True)
 
 
 	def __hash__(self: '_InternalClient') -> int :

--- a/fuzzly/models/internal.py
+++ b/fuzzly/models/internal.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from ..client import Client
 from ..constants import ConfigHost, PostHost, TagHost, UserHost
 from ._database import DBI, FollowKVS, InternalScore, InternalUser, ScoreCache, UserKVS, VoteCache
-from ._shared import Badge, PostId, PostSize, User, UserPortable, UserPrivacy, Verified, _post_id_converter
+from ._shared import PostId, PostSize, User, UserPortable
 from .config import UserConfig
 from .post import MediaType, Post, PostId, PostSize, PostSort, Privacy, Rating, Score
 from .tag import Tag, TagGroupPortable, TagGroups

--- a/fuzzly/models/readme.md
+++ b/fuzzly/models/readme.md
@@ -36,7 +36,7 @@ from fuzzly.models.internal import InternalPosts
 iposts: InternalPosts = InternalPosts()
 iposts.append(ipost)
 # or you can pass in a post list directly
-iposts = InternalPosts([ipost])
+iposts = InternalPosts(post_list=[ipost])
 
 posts: List[Post] = await iposts.posts(client, kh_user)
 ```

--- a/fuzzly/models/readme.md
+++ b/fuzzly/models/readme.md
@@ -29,4 +29,14 @@ client: InternalClient  # an internal client instance is required so that auth c
 post: Post = await ipost.post(client, kh_user)
 user: User = await iuser.user(client, kh_user)
 tag: Tag = await itag.tag(client, kh_user)
+
+# when needing to populate many internal posts use an InternalPosts object
+from fuzzly.models.internal import InternalPosts
+
+iposts: InternalPosts = InternalPosts()
+iposts.append(ipost)
+# or you can pass in a post list directly
+iposts = InternalPosts([ipost])
+
+posts: List[Post] = await iposts.posts(client, kh_user)
 ```

--- a/fuzzly/models/user.py
+++ b/fuzzly/models/user.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from ._shared import UserPrivacy, Verified
+from ._shared import Badge, User, UserPortable, UserPrivacy, Verified
 
 
 class UpdateSelf(BaseModel) :

--- a/fuzzly/models/user.py
+++ b/fuzzly/models/user.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from ._shared import Badge, User, UserPortable, UserPrivacy, Verified
+from ._shared import UserPrivacy, Verified
 
 
 class UpdateSelf(BaseModel) :


### PR DESCRIPTION
[![python-package workflow](https://github.com/kheina-com/fuzzly/actions/workflows/python-package.yml/badge.svg?branch=0.0.3)](https://github.com/kheina-com/fuzzly/actions/workflows/python-package.yml?query=branch:0.0.3)

## Required
- [x] Directory readme files updated
- [ ] ~~Affected wiki/documentation updated~~ _currently, documentation isn't created for internal objects_

## Description
Creates the `fuzzly.models.internal.InternalPosts` object for quickly populating and enriching multiple internal posts due to how long it takes to do so individually

## TODO
- [x] add retrieved objects to cache for all `*_many` DBI calls